### PR TITLE
Fix overhead when loading directory

### DIFF
--- a/src/_h5ai/private/php/core/class-context.php
+++ b/src/_h5ai/private/php/core/class-context.php
@@ -183,7 +183,7 @@ class Context {
         $folder = Item::get($this, $this->to_path($href), $cache);
 
         // add content of subfolders
-        if ($what >= 2 && $folder !== null) {
+        if ($what >= 3 && $folder !== null) {
             foreach ($folder->get_content($cache) as $item) {
                 $item->get_content($cache);
             }
@@ -191,9 +191,14 @@ class Context {
         }
 
         // add content of this folder and all parent folders
-        while ($what >= 1 && $folder !== null) {
+        while ($what >= 2 && $folder !== null) {
             $folder->get_content($cache);
             $folder = $folder->get_parent($cache);
+        }
+
+        // only add the requested folder (less fstat overhead)
+        if ($what == 1 && $folder !== null) {
+            $folder->get_content($cache);
         }
 
         uasort($cache, ['Item', 'cmp']);


### PR DESCRIPTION
* This avoids loading content of parent directories, only adding the requested directory.
* This drastically reduces the amount of fstat system calls, and avoid superfluous items in the response array, i.e. files from directories we don't necessarily care about.
* This should reduce timeouts when loading directories with large numbers of files.